### PR TITLE
Detect and set BinFolder when setting GamePath

### DIFF
--- a/application/GW2 Addon Manager/UI/OpeningPage/OpeningViewModel.cs
+++ b/application/GW2 Addon Manager/UI/OpeningPage/OpeningViewModel.cs
@@ -186,6 +186,7 @@ namespace GW2_Addon_Manager
                 if (value == _gamePath) return;
                 SetProperty(ref _gamePath, value);
                 _configurationManager.UserConfig.GamePath = value;
+                new Configuration(_configurationManager).DetermineSystemType();
                 _configurationManager.SaveConfiguration();
             }
         }


### PR DESCRIPTION
The `BinFolder` config item is detected at application launch, but not when changing the `GamePath`. This can lead to an error if switching from a 32-bit client path to a 64-bit client path. In particular, this problem arises on first application launch if the game is not installed at the default path; the launcher will always complain when changing the path until the config is saved and reloaded.

---

I believe this resolves issue #82 , my steps for replications are as follows:
1. Have the game installed at a non-default directory (in my case, `C:\Program Files (x86)\Guild Wars 2`)
2. Delete `config.xml`, so it is regenerated and defaults are used
3. Launch the application
4. Set the game directory to the one listed above.

I did not test cross-filesystem installations, but I'm assuming the same applies.

---

I've addressed this issue by updating the "select directory" button itself to also update the `BinFolder` config value via a call to `Configuration.DetermineSystemType()`. I think there might be a better option to instead either tweak the `GamePath` setter to automatically do this (and never directly set `BinFolder`), or instead utilize the (currently unused?)`Configuration.SetGamePath()` function that already updates both instead of setting `GamePath` directly.

Let me know if you have any preference, and I'll gladly update this PR