### PR TITLE
Moved TextBlock in UpdatingView to be consistent with Opening View

### DIFF
--- a/application/GW2 Addon Manager/UI/UpdatingPage/UpdatingView.xaml
+++ b/application/GW2 Addon Manager/UI/UpdatingPage/UpdatingView.xaml
@@ -35,6 +35,12 @@
             <Label PreviewMouseDown="TitleBar_MouseHeld"/>
         </DockPanel>
 
+       
+        
+        <Label Grid.Row = "1" FontWeight="Bold" FontSize="60" Foreground="DimGray" Margin="30,0,0,0" FontFamily="Microsoft JhengHei UI Light" Width="Auto" HorizontalAlignment="Left">
+            GW2-UOAOM
+        </Label>
+        <TextBlock Grid.Row="1" Margin="40,75,0,0" FontSize ="16" Foreground="DimGray" FontFamily="Microsoft YaHei UI Light"> Guild Wars 2 - Unofficial Add-On Manager</TextBlock>
         <TextBlock 
             Margin="40, 0, 0, -10"
             HorizontalAlignment="Left"
@@ -56,12 +62,6 @@
                  <TextBlock Text=" Companion Applications" FontFamily="Microsoft YaHei UI"/>
             </Hyperlink>
         </TextBlock>
-        
-        <Label Grid.Row = "1" FontWeight="Bold" FontSize="60" Foreground="DimGray" Margin="30,0,0,0" FontFamily="Microsoft JhengHei UI Light" Width="Auto" HorizontalAlignment="Left">
-            GW2-UOAOM
-        </Label>
-        <TextBlock Grid.Row="1" Margin="40,75,0,0" FontSize ="16" Foreground="DimGray" FontFamily="Microsoft YaHei UI Light"> Guild Wars 2 - Unofficial Add-On Manager</TextBlock>
-
         <Border Grid.Row="2" Width="200" Height="300" HorizontalAlignment="Left" Margin="40,20,0,40" BorderThickness="1" BorderBrush="DimGray" Background="WhiteSmoke">
             <StackPanel Grid.Row ="2" Width="200" Height="300" HorizontalAlignment="Right" VerticalAlignment="Top" Background="WhiteSmoke">
                 <Label Margin="10,10,10,0" HorizontalAlignment="Center" FontFamily="Microsoft YaHei UI" FontSize="16">Thank You!</Label>


### PR DESCRIPTION
When attempting to click hyperlink for Wiki and Companion Applications within the UpdatingView the link would not become clickable towards bottom of link text. Changing the location of the TextBlock to match the location in the Opening iew solved this issue.