### PR TITLE
Add checks for unset game path, and UI warning

### DIFF
--- a/application/GW2AddonManager/App.xaml
+++ b/application/GW2AddonManager/App.xaml
@@ -10,6 +10,7 @@
             </ResourceDictionary.MergedDictionaries>
             <FontFamily x:Key="MDL2Assets">pack://application:,,,/Fonts/#GW2AMMDL2Assets</FontFamily>
             <local:ArrayMultiValueConverter x:Key="ArrayMultiValueConverter"/>
+            <local:BoolVisibilityConverter x:Key="BoolVisibilityConverter"/>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/application/GW2AddonManager/Backend/Utils.cs
+++ b/application/GW2AddonManager/Backend/Utils.cs
@@ -119,4 +119,14 @@ namespace GW2AddonManager
             return (object[])value;
         }
     }
+
+    public class BoolVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return (bool)value ? Visibility.Visible : (object)Visibility.Collapsed;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
+    }
 }

--- a/application/GW2AddonManager/Localization/StaticText.Designer.cs
+++ b/application/GW2AddonManager/Localization/StaticText.Designer.cs
@@ -19,7 +19,7 @@ namespace GW2AddonManager.Localization {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class StaticText {
@@ -489,6 +489,15 @@ namespace GW2AddonManager.Localization {
         public static string SelectAnAddonToSeeMoreInformationAboutIt {
             get {
                 return ResourceManager.GetString("SelectAnAddonToSeeMoreInformationAboutIt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You must set the Game Path before managing addons.
+        /// </summary>
+        public static string SetGamePathRequired {
+            get {
+                return ResourceManager.GetString("SetGamePathRequired", resourceCulture);
             }
         }
         

--- a/application/GW2AddonManager/Localization/StaticText.resx
+++ b/application/GW2AddonManager/Localization/StaticText.resx
@@ -112,10 +112,10 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="French" xml:space="preserve">
     <value>Français</value>
@@ -275,5 +275,8 @@
   </data>
   <data name="InstallDescription" xml:space="preserve">
     <value>Installs the selected addons</value>
+  </data>
+  <data name="SetGamePathRequired" xml:space="preserve">
+    <value>You must set the Game Path before managing addons</value>
   </data>
 </root>

--- a/application/GW2AddonManager/UI/MainWindow/MainWindow.xaml
+++ b/application/GW2AddonManager/UI/MainWindow/MainWindow.xaml
@@ -17,6 +17,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
 
         </Grid.RowDefinitions>
@@ -89,23 +90,23 @@
                     RequestNavigate="Hyperlink_RequestNavigate"
                     TextDecorations="None"
                     FocusVisualStyle="{x:Null}"
-                    ToolTip="{x:Static l:StaticText.ProgramsNotManagedByThisApplication}"
-                    >
-                     <TextBlock Text="{x:Static l:StaticText.CompanionApplicationsWithLeadingSpace}" FontFamily="Microsoft YaHei UI"/>
+                    ToolTip="{x:Static l:StaticText.ProgramsNotManagedByThisApplication}">
+                    <TextBlock Text="{x:Static l:StaticText.CompanionApplicationsWithLeadingSpace}" FontFamily="Microsoft YaHei UI"/>
                 </Hyperlink>
             </TextBlock>
 
             <TextBlock FontFamily="Microsoft JhengHei Light" VerticalAlignment="Center" Margin="15,0,5,0" Text="{x:Static l:StaticText.GamePath}"/>
             <TextBox Text="{Binding GamePath, Mode=OneWay}"
-                 Margin="0,0,5,0"
-                 VerticalAlignment="Center"
-                 Width="350"
-                 Padding="3"
-                 VerticalContentAlignment="Center"
-                 Background="LightGray"
-                 BorderThickness="0"
-                 FontFamily="Consolas"
-                 />
+                     IsReadOnly="True"
+                     Margin="0,0,5,0"
+                     VerticalAlignment="Center"
+                     Width="350"
+                     Padding="3"
+                     VerticalContentAlignment="Center"
+                     Background="LightGray"
+                     BorderThickness="0"
+                     FontFamily="Consolas"
+                     />
             <Button Name="SelectDirectoryBtn"
                 Command="{Binding Path=ChangeGamePath}"
                 Padding="2"
@@ -115,14 +116,21 @@
                 Background="WhiteSmoke"
                 FontFamily="Microsoft YaHei UI Light"
                 BorderBrush="LightGray"
-                Style="{StaticResource BigContentButton}"
-            />
-
+                Style="{StaticResource BigContentButton}"/>
 
         </DockPanel>
 
-        <Label Grid.Row="1" FontWeight="Bold" FontSize="40" Foreground="DimGray" Margin="30,0,0,0" FontFamily="Microsoft JhengHei UI Light" Width="Auto" HorizontalAlignment="Left" Content="Guild Wars 2 Unofficial Addon Manager"/>
+        <Label x:Name="missingGamePath" 
+               Content="{x:Static l:StaticText.SetGamePathRequired}" 
+               Visibility="{Binding Path=GamePathMissing, Converter={StaticResource BoolVisibilityConverter}, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}" 
+               Grid.Row="1" 
+               FontFamily="Microsoft JhengHei UI Light" 
+               FontWeight="Bold" 
+               FontSize="18" 
+               HorizontalContentAlignment="Center"/>
 
-        <Frame x:Name="mainFrame" Source="../OpeningPage/OpeningView.xaml" NavigationUIVisibility="Hidden" Grid.Row="2" VerticalAlignment="Stretch" Margin="40,0,100,0"/>
+        <Label Grid.Row="2" FontWeight="Bold" FontSize="40" Foreground="DimGray" Margin="30,0,0,0" FontFamily="Microsoft JhengHei UI Light" Width="Auto" HorizontalAlignment="Left" Content="Guild Wars 2 Unofficial Addon Manager"/>
+
+        <Frame x:Name="mainFrame" Source="../OpeningPage/OpeningView.xaml" NavigationUIVisibility="Hidden" Grid.Row="3" VerticalAlignment="Stretch" Margin="40,0,100,0"/>
     </Grid>
 </Window>

--- a/application/GW2AddonManager/UI/MainWindow/MainWindow.xaml
+++ b/application/GW2AddonManager/UI/MainWindow/MainWindow.xaml
@@ -8,12 +8,12 @@
     mc:Ignorable="d"
     d:DataContext="{d:DesignInstance Type=a:MainWindowViewModel}"
     x:Class="GW2AddonManager.MainWindow"
-    Title="GW2 Addon Manager" Height="600" Width="1130" ResizeMode="NoResize" WindowStyle="None" AllowsTransparency="True" WindowStartupLocation="CenterScreen">
+    Title="GW2 Addon Manager" Height="650" Width="1130" ResizeMode="NoResize" WindowStyle="None" AllowsTransparency="True" WindowStartupLocation="CenterScreen">
     <Window.Background>
         <ImageBrush ImageSource="/Resources/GW2-UOAOU-UI.png"/>
     </Window.Background>
 
-    <Grid Margin="0,40,0,0">
+    <Grid Margin="0,45,0,0">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>

--- a/application/GW2AddonManager/UI/MainWindow/MainWindowViewModel.cs
+++ b/application/GW2AddonManager/UI/MainWindow/MainWindowViewModel.cs
@@ -38,6 +38,8 @@ namespace GW2AddonManager
 
         public string GamePath => _configurationProvider.UserConfig.GamePath;
 
+        public bool GamePathMissing => _configurationProvider.UserConfig.GamePath == null || _configurationProvider.UserConfig.GamePath == string.Empty;
+
         public ICommand ChangeGamePath => new RelayCommand(() =>
         {
             var pathSelectionDialog = new VistaFolderBrowserDialog();
@@ -47,7 +49,8 @@ namespace GW2AddonManager
                 {
                     GamePath = pathSelectionDialog.SelectedPath
                 };
-                OnPropertyChanged("GamePath");
+                OnPropertyChanged(nameof(GamePath));
+                OnPropertyChanged(nameof(GamePathMissing));
             }
         });
 

--- a/application/GW2AddonManager/UI/MainWindow/MainWindowViewModel.cs
+++ b/application/GW2AddonManager/UI/MainWindow/MainWindowViewModel.cs
@@ -38,7 +38,7 @@ namespace GW2AddonManager
 
         public string GamePath => _configurationProvider.UserConfig.GamePath;
 
-        public bool GamePathMissing => _configurationProvider.UserConfig.GamePath == null || _configurationProvider.UserConfig.GamePath == string.Empty;
+        public bool GamePathMissing => string.IsNullOrEmpty(GamePath);
 
         public ICommand ChangeGamePath => new RelayCommand(() =>
         {

--- a/application/GW2AddonManager/UI/OpeningPage/OpeningViewModel.cs
+++ b/application/GW2AddonManager/UI/OpeningPage/OpeningViewModel.cs
@@ -35,7 +35,7 @@ namespace GW2AddonManager
         private readonly IAddonRepository _addonRepository;
         private readonly ICoreManager _coreManager;
         private readonly IConfigurationProvider _configurationProvider;
-
+              
         public ObservableCollection<AddonInfoCheck> Addons { get; } = new ObservableCollection<AddonInfoCheck>();
         public IEnumerable<AddonInfo> CheckedAddons { get => Addons.Where(x => x.AddonChecked).Select(x => x.Addon); }
 
@@ -52,7 +52,6 @@ namespace GW2AddonManager
             get => _selectedAddon;
             set => SetProperty(ref _selectedAddon, value);
         }
-
 
         [DependsOn("Addons")]
         public bool AnyAddonChecked => Addons.Any(x => x.AddonChecked);
@@ -97,20 +96,20 @@ namespace GW2AddonManager
         public Visibility LogVisibility => Log.Length > 0 ? Visibility.Visible : Visibility.Collapsed;
 
         [DependsOn("Addons")]
-        public bool CanInstallAny => CheckedAddons.Any(x => {
+        public bool CanInstallAny => _configurationProvider.UserConfig.GamePath != null && CheckedAddons.Any(x => {
             bool exists = _configurationProvider.UserConfig.AddonsState.TryGetValue(x.Nickname, out AddonState state);
             return exists && !state.Installed || !exists;
         });
         [DependsOn("Addons")]
-        public bool CanDeleteAny => CheckedAddons.Any(x => {
+        public bool CanDeleteAny => _configurationProvider.UserConfig.GamePath != null && CheckedAddons.Any(x => {
             return _configurationProvider.UserConfig.AddonsState.TryGetValue(x.Nickname, out AddonState state) && state.Installed;
         });
         [DependsOn("Addons")]
-        public bool CanEnableAny => CheckedAddons.Any(x => {
+        public bool CanEnableAny => _configurationProvider.UserConfig.GamePath != null && CheckedAddons.Any(x => {
             return _configurationProvider.UserConfig.AddonsState.TryGetValue(x.Nickname, out AddonState state) && state.Disabled;
         });
         [DependsOn("Addons")]
-        public bool CanDisableAny => CheckedAddons.Any(x => {
+        public bool CanDisableAny => _configurationProvider.UserConfig.GamePath != null && CheckedAddons.Any(x => {
             return _configurationProvider.UserConfig.AddonsState.TryGetValue(x.Nickname, out AddonState state) && !state.Disabled;
         });
 

--- a/application/GW2AddonManager/UI/OpeningPage/OpeningViewModel.cs
+++ b/application/GW2AddonManager/UI/OpeningPage/OpeningViewModel.cs
@@ -35,7 +35,10 @@ namespace GW2AddonManager
         private readonly IAddonRepository _addonRepository;
         private readonly ICoreManager _coreManager;
         private readonly IConfigurationProvider _configurationProvider;
-              
+
+        public string GamePath => _configurationProvider.UserConfig.GamePath;
+        public bool GamePathMissing => string.IsNullOrEmpty(GamePath);
+
         public ObservableCollection<AddonInfoCheck> Addons { get; } = new ObservableCollection<AddonInfoCheck>();
         public IEnumerable<AddonInfo> CheckedAddons { get => Addons.Where(x => x.AddonChecked).Select(x => x.Addon); }
 
@@ -96,20 +99,20 @@ namespace GW2AddonManager
         public Visibility LogVisibility => Log.Length > 0 ? Visibility.Visible : Visibility.Collapsed;
 
         [DependsOn("Addons")]
-        public bool CanInstallAny => _configurationProvider.UserConfig.GamePath != null && CheckedAddons.Any(x => {
+        public bool CanInstallAny => !GamePathMissing && CheckedAddons.Any(x => {
             bool exists = _configurationProvider.UserConfig.AddonsState.TryGetValue(x.Nickname, out AddonState state);
             return exists && !state.Installed || !exists;
         });
         [DependsOn("Addons")]
-        public bool CanDeleteAny => _configurationProvider.UserConfig.GamePath != null && CheckedAddons.Any(x => {
+        public bool CanDeleteAny => !GamePathMissing && CheckedAddons.Any(x => {
             return _configurationProvider.UserConfig.AddonsState.TryGetValue(x.Nickname, out AddonState state) && state.Installed;
         });
         [DependsOn("Addons")]
-        public bool CanEnableAny => _configurationProvider.UserConfig.GamePath != null && CheckedAddons.Any(x => {
+        public bool CanEnableAny => !GamePathMissing && CheckedAddons.Any(x => {
             return _configurationProvider.UserConfig.AddonsState.TryGetValue(x.Nickname, out AddonState state) && state.Disabled;
         });
         [DependsOn("Addons")]
-        public bool CanDisableAny => _configurationProvider.UserConfig.GamePath != null && CheckedAddons.Any(x => {
+        public bool CanDisableAny => !GamePathMissing && CheckedAddons.Any(x => {
             return _configurationProvider.UserConfig.AddonsState.TryGetValue(x.Nickname, out AddonState state) && !state.Disabled;
         });
 


### PR DESCRIPTION
This adds checks to prevent user managing addons before GamePath is set (and subsequently displaying an unhelpful error message). It also adds text to the MainWindow informing user the game path must be set (visible only when GamePath not set).